### PR TITLE
fix plugin to work well with auxiliaryComment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ logs
 
 # Dependency directory
 node_modules
+lib

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+*.log
+src

--- a/index.js
+++ b/index.js
@@ -1,9 +1,0 @@
-module.exports = function (babel) {
-	return new babel.Transformer("object-assign", {
-		CallExpression: function (node, parent, scope, file) {
-			if (this.get("callee").matchesPattern("Object.assign")) {
-				node.callee = file.addHelper("extends");
-			}
-		}
-	});
-};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "babel-plugin-object-assign",
   "version": "1.1.0",
   "description": "Babel plugin to replace Object.assign with the extends helper",
-  "main": "index.js",
   "author": "Jed Watson",
   "license": "MIT",
   "repository": {
@@ -11,6 +10,15 @@
   },
   "peerDependencies": {
     "babel-core": ">=5.2.0"
+  },
+  "main": "lib/index.js",
+  "devDependencies": {
+    "babel": "^5.6.0"
+  },
+  "scripts": {
+    "build": "babel-plugin build",
+    "push": "babel-plugin publish",
+    "test": "babel-plugin test"
   },
   "keywords": [
     "babel",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,15 @@
+export default function ({ Plugin, types: t }) {
+  return new Plugin("object-assign", {
+    metadata: {
+      group: "builtin-pre"
+    },
+
+    visitor: {
+      CallExpression: function (node, parent, scope, file) {
+        if (this.get("callee").matchesPattern("Object.assign")) {
+          node.callee = file.addHelper("extends");
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
Without this fix the plugin doesn't play well with `auxiliaryComment`, the output looks like this:
```js
// istanbul ignore next
"use strict";

exports.__esModule = true;

var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };

```
The `auxiliaryComment` isn't before the helper function.

With this fix it is before the helper:
```js
"use strict";

exports.__esModule = true;
// istanbul ignore next

var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
```


This PR also changes the plugin to have the same structure as the other [babel-plugins](https://github.com/babel-plugins)

I hope this is okay for you?

refs https://github.com/1-liners/1-liners/pull/105
refs https://github.com/babel/babel/issues/1715