### PR TITLE
update README, use --save-dev rather than --save

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Instead of using `_.extend(obj1, obj2...)` or `xtend(obj1, obj2...)` just use `O
 Install:
 
 ```
-$ npm install babel babel-core babel-plugin-object-assign --save
+$ npm install babel babel-core babel-plugin-object-assign --save-dev
 ```
 
 _Note:_ you need to specify `babel-core` as a dependency for your project (not just `babel`). This is also true if you are using a wrapper like `babelify`.
@@ -34,7 +34,7 @@ require("babel").transform("code", { plugins: ["object-assign"] });
 with `browserify` / `babelify`:
 
 ```
-$ npm install babelify babel-core babel-plugin-object-assign --save
+$ npm install babelify babel-core babel-plugin-object-assign --save-dev
 ```
 
 ```js


### PR DESCRIPTION
babel, babel-core, babel-plugin-object-assign are only
needed at development time, so using --save-dev should
be sufficient.